### PR TITLE
feat: ユーザー定義IDの空チェック実装

### DIFF
--- a/src/utils/validation.js
+++ b/src/utils/validation.js
@@ -125,6 +125,13 @@ export function validateEquipment(equipment) {
         `id は "${ID_PREFIX.MASTER_EQUIPMENT}" または "${ID_PREFIX.USER_EQUIPMENT}" で始まる必要があります`
       );
     }
+
+    // ユーザー定義IDの場合、プレフィックス後が空でないことをチェック
+    if (equipment.id.startsWith(ID_PREFIX.USER_EQUIPMENT)) {
+      if (!isValidUserEquipmentId(equipment.id)) {
+        errors.push('ユーザー定義装備のIDはプレフィックス後に内容が必要です');
+      }
+    }
   }
 
   // 文字数制限チェック
@@ -181,6 +188,13 @@ export function validateMission(mission) {
       errors.push(
         `id は "${ID_PREFIX.MASTER_MISSION}" または "${ID_PREFIX.USER_MISSION}" で始まる必要があります`
       );
+    }
+
+    // ユーザー定義IDの場合、プレフィックス後が空でないことをチェック
+    if (mission.id.startsWith(ID_PREFIX.USER_MISSION)) {
+      if (!isValidUserMissionId(mission.id)) {
+        errors.push('ユーザー定義任務のIDはプレフィックス後に内容が必要です');
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

* validateEquipment 関数にユーザー定義装備IDの空チェックを追加
* validateMission 関数にユーザー定義任務IDの空チェックを追加
* 既存の isValidUserEquipmentId/isValidUserMissionId 関数を活用

これにより u_eq_ や u_ms_ のような不正なIDをバリデーションで検出可能.

## Changes

* `src/utils/validation.js`
  * validateEquipment: ユーザー定義装備IDの場合、プレフィックス後が空でないことをチェック
  * validateMission: ユーザー定義任務IDの場合、プレフィックス後が空でないことをチェック

## Related Issues

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)