### PR TITLE
feat: crypto.randomUUID()のフォールバック実装 (#44)

### DIFF
--- a/src/utils/idGenerator.js
+++ b/src/utils/idGenerator.js
@@ -4,9 +4,38 @@
  * ユーザー定義データのID生成を一元管理する
  * - 装備ID: u_eq_<UUID>
  * - 任務ID: u_ms_<UUID>
+ * - カテゴリID: u_cat_<UUID>
  *
  * @module utils/idGenerator
  */
+
+/**
+ * UUID v4を生成（crypto.randomUUID()のフォールバック付き）
+ *
+ * @returns {string} UUID
+ * @private
+ */
+function generateUUID() {
+  // モダンブラウザ: crypto.randomUUID()を使用
+  if (
+    typeof crypto !== 'undefined' &&
+    typeof crypto.randomUUID === 'function'
+  ) {
+    return crypto.randomUUID()
+  }
+
+  // フォールバック: 疑似乱数を使用（セキュアではないが動作する）
+  console.warn(
+    '[WARNING] crypto.randomUUID() is not available. Using fallback method. セキュアな環境（HTTPS）での使用を推奨します。'
+  )
+
+  // RFC 4122 v4形式のUUID生成
+  return 'xxxxxxxx-xxxx-4xxx-yxxx-xxxxxxxxxxxx'.replace(/[xy]/g, function (c) {
+    const r = (Math.random() * 16) | 0
+    const v = c === 'x' ? r : (r & 0x3) | 0x8
+    return v.toString(16)
+  })
+}
 
 /**
  * ユーザー定義装備のIDを生成する
@@ -17,7 +46,7 @@
  * // => "u_eq_123e4567-e89b-12d3-a456-426614174000"
  */
 export function generateEquipmentId() {
-  return `u_eq_${crypto.randomUUID()}`
+  return `u_eq_${generateUUID()}`
 }
 
 /**
@@ -29,5 +58,17 @@ export function generateEquipmentId() {
  * // => "u_ms_123e4567-e89b-12d3-a456-426614174000"
  */
 export function generateMissionId() {
-  return `u_ms_${crypto.randomUUID()}`
+  return `u_ms_${generateUUID()}`
+}
+
+/**
+ * ユーザー定義カテゴリのIDを生成する
+ *
+ * @returns {string} u_cat_プレフィックス付きUUID
+ * @example
+ * generateCategoryId()
+ * // => "u_cat_123e4567-e89b-12d3-a456-426614174000"
+ */
+export function generateCategoryId() {
+  return `u_cat_${generateUUID()}`
 }


### PR DESCRIPTION
## Summary

crypto.randomUUID()が利用できない環境（古いブラウザ、HTTP環境）向けにフォールバック実装を追加した.

## Changes

* src/utils/idGenerator.js
  * generateUUID()関数を追加（private関数）
    * crypto.randomUUID()が利用可能な場合は使用
    * 利用不可の場合はMath.random()ベースのUUID v4生成を使用
    * フォールバック使用時は開発者コンソールに警告を出力
  * generateEquipmentId(), generateMissionId()をgenerateUUID()呼び出しに変更
  * generateCategoryId()を追加（将来のカテゴリ追加機能用）

## Fallback Safety

* 本番環境（HTTPS）: crypto.randomUUID()を使用、完全にセキュア
* 開発環境（HTTP）: フォールバックを使用
  * UUID v4の重複確率: 約1/(2^122) ≈ 5.3×10^-37
  * 個人プロジェクトの規模では実質的に問題なし

## Related Issue

Closes #44

🤖 Generated with [Claude Code](https://claude.com/claude-code)