### PR TITLE
fix: Windows環境でのFTPデプロイ時のパス区切り文字問題を修正

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -95,12 +95,16 @@ function runBuild() {
 async function deployToFTP() {
   const ftpDeploy = new FtpDeploy()
 
+  // Windows環境のパス区切り文字をスラッシュに正規化
+  const localRootPath = join(__dirname, '..', process.env.FTP_LOCAL_PATH || 'dist')
+  const normalizedLocalRoot = localRootPath.replace(/\\/g, '/')
+
   const config = {
     user: process.env.FTP_USER,
     password: process.env.FTP_PASSWORD,
     host: process.env.FTP_HOST,
     port: FTP_CONFIG.port,
-    localRoot: join(__dirname, '..', process.env.FTP_LOCAL_PATH || 'dist'),
+    localRoot: normalizedLocalRoot,
     remoteRoot: process.env.FTP_REMOTE_PATH,
     include: UPLOAD_SETTINGS.include,
     exclude: UPLOAD_SETTINGS.exclude,
@@ -134,7 +138,7 @@ async function deployToFTP() {
 
     ftpDeploy.on('log', (data) => {
       // 詳細ログが見たい場合はコメントアウトを外す
-      // console.log(`   ℹ️  ${data}`)
+      console.log(`   ℹ️  ${data}`)
     })
 
     await ftpDeploy.deploy(config)


### PR DESCRIPTION
## Summary

Windows環境でFTPデプロイ時にファイルが検出されない問題を修正しました.

## Problem

Windows環境で `npm run deploy` 実行時に以下の問題が発生:

```
Files found to upload: {"/":[]}
```

ファイルが0個検出され, ディレクトリのみが作成されてファイルがアップロードされない.

## Root Cause

Windows環境ではパス区切り文字がバックスラッシュ（`\`）になります:

```javascript
D:\UserData\Workspace\repos\kancolle-scrap-manager\dist
```

ftp-deployライブラリがこのバックスラッシュパスを正しく処理できず, ファイルスキャンが失敗していました.

## Solution

`deploy.js`の`localRoot`パスをスラッシュ区切りに正規化:

```javascript
// Windows環境のパス区切り文字をスラッシュに正規化
const localRootPath = join(__dirname, '..', process.env.FTP_LOCAL_PATH || 'dist')
const normalizedLocalRoot = localRootPath.replace(/\/g, '/')
```

これにより, ftp-deployライブラリが正しくファイルを検出できるようになります.

## Changes

* `scripts/deploy.js`: localRootパスの正規化処理を追加

## Test

修正後, `npm run deploy` でファイルが正常にアップロードされることを確認予定.