### PR TITLE
docs: Issue74完了後のリファクタ検討をprogress_v2に追記

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -23,14 +23,14 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 ### Development Flow
 
 1. check current branch status with `git status`
-1. check issue and `progress.md` for next tasks
+1. check issue and `docs/progress_v2.md` for next tasks
     * Must: check comments of related issues for additional context
 1. create branch with rule in `copilot-instructions.md` from main branch
     * `<prefix>/<yyyymm>/sakashita44/<issue-number: if exists>-<short-description>`
     * e.g. `feat/202511/sakashita44/5-add-validation`
 1. implement feature / fix bug
 1. test locally
-1. update `docs/progress.md` if task affects progress
+1. update `docs/progress_v2.md` if task affects progress
 1. commit with rule in `copilot-instructions.md`
 1. push to remote
 1. create pull request
@@ -258,4 +258,5 @@ The app implements 4-level error classification with comprehensive recovery stra
 * `docs/ui_specification.md` - Detailed UI/UX specifications including modal behaviors and filter combinations
 * `docs/error_handling.md` - Error classification (4 levels), recovery strategies, and validation on startup
 * `docs/import_export.md` - Import/export file formats, validation flow, and filename generation rules
-* `docs/progress.md` - Project progress tracking and next steps
+* `docs/progress_v2.md` - v2.0.0 roadmap and progress tracking (current)
+* `docs/progress.md` - v1.0.0 progress tracking (archived)

--- a/docs/progress_v2.md
+++ b/docs/progress_v2.md
@@ -1,6 +1,6 @@
 # v2.0.0 ロードマップ
 
-最終更新: 2025-11-29
+最終更新: 2025-12-03
 
 ## 概要
 
@@ -92,7 +92,47 @@ v2.0.0の機能は以下の順序で実装する：
 - コミット: e9cdf12（Phase 0-1）、ca8b7d5（MissionCard修正）、c232760（scrapListFormatters修正）
 - Phase 2-4: ランタイムロジック、UI変更の実装完了
 - Phase 5: ユーザーカテゴリ機能の実装完了、動作確認OK
-- 今後の課題: データ変換層の導入検討（別issue推奨）
+- 今後の課題: コードベースのリファクタが必要（詳細は以下）
+
+### Phase 1完了後のリファクタ検討 (2025-12-03)
+
+Issue74実装後、責務分離が曖昧になった点を調査し、複数のリファクタIssueを起票した。
+
+**調査結果**:
+
+1. **データ変換処理の散在**: `isMaster`付与が4箇所、`type`除外が3箇所に分散
+2. **フック層の責務過多**: 変換 + 状態管理 + CRUD + Map生成を1つのフックで実施
+3. **localStorage層の責務混在**: 永続化とデータ変換の2つの責務を持つ
+4. **App.jxの肥大化**: ビジネスロジックがUI層に混在（344行）
+5. **エラーハンドリングの不統一**: 未使用エラー状態、部分的な統合
+
+**起票したリファクタIssue**:
+
+| Issue | タイトル | 優先度 | 説明 |
+|:------|:---------|:-------|:-----|
+| [#80](https://github.com/sakashita44/kancolle-scrap-manager/issues/80) | データ変換層の導入によるコード責務の明確化 | 高 | 永続化形式とランタイム形式の変換を専用層に集約 |
+| [#83](https://github.com/sakashita44/kancolle-scrap-manager/issues/83) | App.jxのビジネスロジックをドメイン層に分離 | 中 | カテゴリ削除などのビジネスロジックをドメイン層に移動 |
+| [#84](https://github.com/sakashita44/kancolle-scrap-manager/issues/84) | ユーザーデータ管理フックの統合 | 低 | useUserDataLoaderとuseUserDataCRUDを1つに統合 |
+| [#85](https://github.com/sakashita44/kancolle-scrap-manager/issues/85) | エラーハンドリングの統一と一元管理 | 低 | 全てのエラーを統一された方法で管理 |
+| [#86](https://github.com/sakashita44/kancolle-scrap-manager/issues/86) | validation.jsの重複パターンをスキーマベースに共通化 | 低 | スキーマ定義ベースの汎用バリデーション関数を作成 |
+
+**推奨実装順序**:
+
+1. **最優先**: Issue #80（データ変換層の導入） - 他のリファクタの基盤となる
+2. **次点**: Issue #83（App.jxのビジネスロジック分離） - 機能追加前に対処推奨
+3. **その後**: Issue #84, #85, #86 - 必要に応じて実装
+
+**Issue #80の概要**:
+
+新規ファイル `src/utils/dataConverter.js` を作成し、以下を集約：
+- `toRuntimeCategories()`, `toRuntimeEquipments()`, `toRuntimeMissions()` - 永続化形式 → ランタイム形式
+- `toPersistCategories()`, `toPersistEquipments()`, `toPersistMissions()` - ランタイム形式 → 永続化形式
+- `generateCategoryRepresentatives()` - カテゴリ代表装備の動的生成
+- `createCategoryMaps()`, `createEquipmentMap()` - Map生成
+
+命名規則の統一も同時に実施:
+- `allEquipmentsForUI` → `equipmentsForUI`
+- 他のフックも同様に統一
 
 ## Phase 2: 計算ロジック拡張
 


### PR DESCRIPTION
## 概要

Issue74実装後に責務分離の問題点を調査し、リファクタ案をIssue化した内容を `docs/progress_v2.md` に追記。

## 変更内容

### `docs/progress_v2.md`

Phase 1完了後のリファクタ検討セクションを追加:

**調査結果**:
1. データ変換処理の散在（`isMaster`付与が4箇所、`type`除外が3箇所）
2. フック層の責務過多（変換 + 状態管理 + CRUD + Map生成）
3. localStorage層の責務混在（永続化とデータ変換）
4. App.jxの肥大化（ビジネスロジックがUI層に混在、344行）
5. エラーハンドリングの不統一（未使用エラー状態、部分的な統合）

**起票したリファクタIssue**:
- #80: データ変換層の導入（優先度: 高）
- #83: App.jxのビジネスロジック分離（優先度: 中）
- #84: ユーザーデータ管理フックの統合（優先度: 低）
- #85: エラーハンドリングの統一（優先度: 低）
- #86: validation.jsのスキーマベース共通化（優先度: 低）

**推奨実装順序**:
1. 最優先: Issue #80（他のリファクタの基盤）
2. 次点: Issue #83（機能追加前に対処推奨）
3. その後: Issue #84, #85, #86（必要に応じて）

### `CLAUDE.md`

Development FlowとKey Documentation Filesのセクションを更新:
- `progress.md` → `progress_v2.md` に参照を更新
- `progress_v2.md` を現行資料、`progress.md` をアーカイブとして明記

## 関連Issue

- #74（完了）: カテゴリ代表装備の動的生成
- #80: データ変換層の導入
- #83: App.jxのビジネスロジック分離
- #84: ユーザーデータ管理フックの統合
- #85: エラーハンドリングの統一
- #86: validation.jsの共通化