### PR TITLE
refactor: データ変換層の導入によるコード責務の明確化 (#80)

### DIFF
--- a/docs/progress_v2.md
+++ b/docs/progress_v2.md
@@ -108,31 +108,47 @@ Issue74実装後、責務分離が曖昧になった点を調査し、複数の�
 
 **起票したリファクタIssue**:
 
-| Issue | タイトル | 優先度 | 説明 |
-|:------|:---------|:-------|:-----|
-| [#80](https://github.com/sakashita44/kancolle-scrap-manager/issues/80) | データ変換層の導入によるコード責務の明確化 | 高 | 永続化形式とランタイム形式の変換を専用層に集約 |
-| [#83](https://github.com/sakashita44/kancolle-scrap-manager/issues/83) | App.jxのビジネスロジックをドメイン層に分離 | 中 | カテゴリ削除などのビジネスロジックをドメイン層に移動 |
-| [#84](https://github.com/sakashita44/kancolle-scrap-manager/issues/84) | ユーザーデータ管理フックの統合 | 低 | useUserDataLoaderとuseUserDataCRUDを1つに統合 |
-| [#85](https://github.com/sakashita44/kancolle-scrap-manager/issues/85) | エラーハンドリングの統一と一元管理 | 低 | 全てのエラーを統一された方法で管理 |
-| [#86](https://github.com/sakashita44/kancolle-scrap-manager/issues/86) | validation.jsの重複パターンをスキーマベースに共通化 | 低 | スキーマ定義ベースの汎用バリデーション関数を作成 |
+| Issue | タイトル | 優先度 | 説明 | ステータス |
+|:------|:---------|:-------|:-----|:-----------|
+| [#80](https://github.com/sakashita44/kancolle-scrap-manager/issues/80) | データ変換層の導入によるコード責務の明確化 | 高 | 永続化形式とランタイム形式の変換を専用層に集約 | ✅ 完了 |
+| [#83](https://github.com/sakashita44/kancolle-scrap-manager/issues/83) | App.jxのビジネスロジックをドメイン層に分離 | 中 | カテゴリ削除などのビジネスロジックをドメイン層に移動 | 未着手 |
+| [#84](https://github.com/sakashita44/kancolle-scrap-manager/issues/84) | ユーザーデータ管理フックの統合 | 低 | useUserDataLoaderとuseUserDataCRUDを1つに統合 | 未着手 |
+| [#85](https://github.com/sakashita44/kancolle-scrap-manager/issues/85) | エラーハンドリングの統一と一元管理 | 低 | 全てのエラーを統一された方法で管理 | 未着手 |
+| [#86](https://github.com/sakashita44/kancolle-scrap-manager/issues/86) | validation.jsの重複パターンをスキーマベースに共通化 | 低 | スキーマ定義ベースの汎用バリデーション関数を作成 | 未着手 |
 
 **推奨実装順序**:
 
-1. **最優先**: Issue #80（データ変換層の導入） - 他のリファクタの基盤となる
+1. **最優先**: Issue #80（データ変換層の導入） - 他のリファクタの基盤となる ✅ 完了
 2. **次点**: Issue #83（App.jxのビジネスロジック分離） - 機能追加前に対処推奨
 3. **その後**: Issue #84, #85, #86 - 必要に応じて実装
 
-**Issue #80の概要**:
+### Issue #80: データ変換層の導入 (2025-12-03)
+
+**実装内容**:
 
 新規ファイル `src/utils/dataConverter.js` を作成し、以下を集約：
 - `toRuntimeCategories()`, `toRuntimeEquipments()`, `toRuntimeMissions()` - 永続化形式 → ランタイム形式
 - `toPersistCategories()`, `toPersistEquipments()`, `toPersistMissions()` - ランタイム形式 → 永続化形式
 - `generateCategoryRepresentatives()` - カテゴリ代表装備の動的生成
+- `addEquipmentType()` - 装備にtypeフィールドを付与
 - `createCategoryMaps()`, `createEquipmentMap()` - Map生成
 
 命名規則の統一も同時に実施:
 - `allEquipmentsForUI` → `equipmentsForUI`
-- 他のフックも同様に統一
+- `App.jsx`での使用箇所も更新
+
+**リファクタした箇所**:
+- `src/hooks/useCategories.js`: `toRuntimeCategories()`, `createCategoryMaps()`を使用
+- `src/hooks/useEquipments.js`: `toRuntimeEquipments()`, `generateCategoryRepresentatives()`, `addEquipmentType()`, `createEquipmentMap()`を使用
+- `src/hooks/useMissions.js`: `toRuntimeMissions()`を使用
+- `src/utils/localStorage.js`: `toPersist*()`, `toRuntime*()`を使用して変換処理を集約
+
+**効果**:
+- データ変換処理の重複を解消（4箇所 → 1箇所）
+- 責務の明確化（永続化層、変換層、フック層の分離）
+- 保守性とテスタビリティの向上
+
+**ステータス**: 完了 (2025-12-03)
 
 ## Phase 2: 計算ロジック拡張
 

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -32,7 +32,7 @@ function App() {
     getNextOrder: getNextCategoryOrder
   } = useCategories()
   const {
-    allEquipmentsForUI: equipments,
+    equipmentsForUI: equipments,
     equipmentMap,
     userEquipments,
     getNextOrder: getNextEquipmentOrder,

--- a/src/hooks/useCategories.js
+++ b/src/hooks/useCategories.js
@@ -10,6 +10,7 @@ import { loadUserCategories, saveUserCategories } from '../utils/localStorage.js
 import { getNextOrder as getNextOrderUtil, mergeAndSort, createDefaultSortComparator } from '../utils/dataManagement.js';
 import { useUserDataLoader } from './useUserDataLoader.js';
 import { useUserDataCRUD } from './useUserDataCRUD.js';
+import { toRuntimeCategories, createCategoryMaps } from '../utils/dataConverter.js';
 
 /**
  * カテゴリデータを管理するカスタムフック
@@ -21,10 +22,7 @@ export function useCategories() {
 
   // マスタデータをインポート（isMasterフラグを付与）
   const masterCategories = useMemo(() => {
-    return categoriesData.categories.map(cat => ({
-      ...cat,
-      isMaster: true
-    }));
+    return toRuntimeCategories(categoriesData.categories, true);
   }, []);
 
   // ユーザー定義カテゴリをLocalStorageから読込
@@ -51,34 +49,15 @@ export function useCategories() {
   // categories配列（後方互換性のため）
   const categories = useMemo(() => allCategories, [allCategories]);
 
-  // カテゴリID→カテゴリオブジェクトのMap
-  const categoryMap = useMemo(() => {
-    const map = new Map();
-    categories.forEach((cat) => {
-      map.set(cat.id, cat);
-    });
-    return map;
-  }, [categories]);
-
-  // カテゴリIDからカテゴリ名への変換Map（order順にソート済み）
-  const categoryNameMap = useMemo(() => {
-    const map = new Map();
-    // categoriesは既にorder順にソート済み（isMaster: trueで取得）
-    categories.forEach((cat) => {
-      map.set(cat.id, cat.name);
-    });
-    return map;
+  // カテゴリ関連のMap生成
+  const { categoryMap, categoryNameMap, categoryIds } = useMemo(() => {
+    return createCategoryMaps(categories);
   }, [categories]);
 
   // カテゴリIDからカテゴリ名を取得
   const getCategoryName = useCallback((categoryId) => {
     return categoryNameMap.get(categoryId) || categoryId;
   }, [categoryNameMap]);
-
-  // カテゴリIDのリストを取得（order順）
-  const categoryIds = useMemo(() => {
-    return categories.map(cat => cat.id);
-  }, [categories]);
 
   // ユーザー定義カテゴリの次の order 値を取得
   const getNextOrder = useCallback(() => {

--- a/src/hooks/useEquipments.js
+++ b/src/hooks/useEquipments.js
@@ -10,7 +10,7 @@ import { loadUserEquipments, saveUserEquipments } from '../utils/localStorage.js
 import { getNextOrder as getNextOrderUtil, mergeAndSort, createDefaultSortComparator } from '../utils/dataManagement.js';
 import { useUserDataLoader } from './useUserDataLoader.js';
 import { useUserDataCRUD } from './useUserDataCRUD.js';
-import { EQUIPMENT_TYPE } from '../types/schema.js';
+import { toRuntimeEquipments, generateCategoryRepresentatives, addEquipmentType, createEquipmentMap } from '../utils/dataConverter.js';
 
 /**
  * 装備データを管理するカスタムフック
@@ -24,10 +24,7 @@ export function useEquipments(categories, categoryMap) {
 
   // マスタデータをインポート（isMasterフラグを付与）
   const masterEquipments = useMemo(() => {
-    return equipmentsData.equipments.map(eq => ({
-      ...eq,
-      isMaster: true
-    }));
+    return toRuntimeEquipments(equipmentsData.equipments, true);
   }, []);
 
   // ユーザー定義装備をLocalStorageから読込
@@ -44,26 +41,16 @@ export function useEquipments(categories, categoryMap) {
 
   // 装備検索用Map（カテゴリ代表は含まない）
   const equipmentMap = useMemo(() => {
-    return new Map(equipments.map(eq => [eq.id, eq]));
+    return createEquipmentMap(equipments);
   }, [equipments]);
 
   // UI表示用にカテゴリ代表を動的生成してマージ
-  const allEquipmentsForUI = useMemo(() => {
+  const equipmentsForUI = useMemo(() => {
     // カテゴリ代表を動的生成
-    const categoryReps = categories.map(cat => ({
-      id: cat.id,                    // カテゴリIDをそのまま使用
-      name: cat.name + '（種別不問）',
-      categoryId: cat.id,
-      isMaster: cat.isMaster,
-      type: EQUIPMENT_TYPE.CATEGORY,
-      order: cat.order
-    }));
+    const categoryReps = generateCategoryRepresentatives(categories);
 
     // 装備にtypeフィールドを付与
-    const equipmentsWithType = equipments.map(eq => ({
-      ...eq,
-      type: EQUIPMENT_TYPE.ITEM
-    }));
+    const equipmentsWithType = addEquipmentType(equipments);
 
     // マージしてソート
     return [...categoryReps, ...equipmentsWithType].sort((a, b) => {
@@ -83,8 +70,8 @@ export function useEquipments(categories, categoryMap) {
 
   // IDで装備を検索（UI表示用リストから検索）
   const findEquipmentById = useCallback((equipmentId) => {
-    return allEquipmentsForUI.find((eq) => eq.id === equipmentId) || null;
-  }, [allEquipmentsForUI]);
+    return equipmentsForUI.find((eq) => eq.id === equipmentId) || null;
+  }, [equipmentsForUI]);
 
   // ユーザー定義装備の次の order 値を取得
   const getNextOrder = useCallback(() => {
@@ -94,8 +81,8 @@ export function useEquipments(categories, categoryMap) {
   return {
     // データ
     equipments,           // 装備のみ（カテゴリ代表は含まない）
-    allEquipmentsForUI,   // UI表示用（カテゴリ代表 + 装備、typeで区別）
-    allEquipments: allEquipmentsForUI, // 後方互換性のため
+    equipmentsForUI,      // UI表示用（カテゴリ代表 + 装備、typeで区別）
+    allEquipments: equipmentsForUI, // 後方互換性のため
     masterEquipments,
     userEquipments,
 

--- a/src/hooks/useMissions.js
+++ b/src/hooks/useMissions.js
@@ -11,6 +11,7 @@ import { PERIOD_ORDER } from '../types/schema.js';
 import { getNextOrder as getNextOrderUtil, mergeAndSort, createMissionSortComparator } from '../utils/dataManagement.js';
 import { useUserDataLoader } from './useUserDataLoader.js';
 import { useUserDataCRUD } from './useUserDataCRUD.js';
+import { toRuntimeMissions } from '../utils/dataConverter.js';
 
 /**
  * 任務データを管理するカスタムフック
@@ -22,10 +23,7 @@ export function useMissions() {
 
   // マスタデータをインポート（isMasterフラグを付与）
   const masterMissions = useMemo(() => {
-    return missionsData.missions.map(ms => ({
-      ...ms,
-      isMaster: true
-    }));
+    return toRuntimeMissions(missionsData.missions, true);
   }, []);
 
   // ユーザー定義任務をLocalStorageから読込

--- a/src/utils/dataConverter.js
+++ b/src/utils/dataConverter.js
@@ -1,0 +1,133 @@
+/**
+ * データ変換層
+ * 永続化形式（JSON/LocalStorage）とランタイム形式（アプリケーション内部）間の変換を担当
+ * @module utils/dataConverter
+ */
+
+import { EQUIPMENT_TYPE } from '../types/schema.js';
+
+/**
+ * 永続化形式 → ランタイム形式: カテゴリ
+ * @param {Array} persistedCategories - 永続化形式のカテゴリ配列
+ * @param {boolean} isMaster - マスタデータかどうか
+ * @returns {Array} ランタイム形式のカテゴリ配列
+ */
+export function toRuntimeCategories(persistedCategories, isMaster) {
+  return persistedCategories.map(cat => ({
+    ...cat,
+    isMaster,
+  }));
+}
+
+/**
+ * 永続化形式 → ランタイム形式: 装備
+ * @param {Array} persistedEquipments - 永続化形式の装備配列
+ * @param {boolean} isMaster - マスタデータかどうか
+ * @returns {Array} ランタイム形式の装備配列
+ */
+export function toRuntimeEquipments(persistedEquipments, isMaster) {
+  return persistedEquipments.map(eq => ({
+    ...eq,
+    isMaster,
+  }));
+}
+
+/**
+ * 永続化形式 → ランタイム形式: 任務
+ * @param {Array} persistedMissions - 永続化形式の任務配列
+ * @param {boolean} isMaster - マスタデータかどうか
+ * @returns {Array} ランタイム形式の任務配列
+ */
+export function toRuntimeMissions(persistedMissions, isMaster) {
+  return persistedMissions.map(ms => ({
+    ...ms,
+    isMaster,
+  }));
+}
+
+/**
+ * カテゴリ代表装備を動的生成
+ * @param {Array} runtimeCategories - ランタイム形式のカテゴリ配列
+ * @returns {Array} カテゴリ代表装備の配列
+ */
+export function generateCategoryRepresentatives(runtimeCategories) {
+  return runtimeCategories.map(cat => ({
+    id: cat.id,
+    name: cat.name + '（種別不問）',
+    categoryId: cat.id,
+    isMaster: cat.isMaster,
+    type: EQUIPMENT_TYPE.CATEGORY,
+    order: cat.order,
+  }));
+}
+
+/**
+ * 装備にtypeフィールドを付与
+ * @param {Array} equipments - ランタイム形式の装備配列（type未付与）
+ * @returns {Array} ランタイム形式の装備配列（type付与済み）
+ */
+export function addEquipmentType(equipments) {
+  return equipments.map(eq => ({
+    ...eq,
+    type: EQUIPMENT_TYPE.ITEM,
+  }));
+}
+
+/**
+ * カテゴリ関連のMap生成
+ * @param {Array} categories - ランタイム形式のカテゴリ配列
+ * @returns {Object} categoryMap, categoryNameMap, categoryIds を含むオブジェクト
+ */
+export function createCategoryMaps(categories) {
+  const categoryMap = new Map();
+  const categoryNameMap = new Map();
+
+  categories.forEach((cat) => {
+    categoryMap.set(cat.id, cat);
+    categoryNameMap.set(cat.id, cat.name);
+  });
+
+  const categoryIds = categories.map(cat => cat.id);
+
+  return {
+    categoryMap,
+    categoryNameMap,
+    categoryIds,
+  };
+}
+
+/**
+ * 装備検索用Map生成
+ * @param {Array} equipments - ランタイム形式の装備配列（カテゴリ代表を含まない）
+ * @returns {Map} equipmentMap
+ */
+export function createEquipmentMap(equipments) {
+  return new Map(equipments.map(eq => [eq.id, eq]));
+}
+
+/**
+ * ランタイム形式 → 永続化形式: カテゴリ
+ * @param {Array} runtimeCategories - ランタイム形式のカテゴリ配列
+ * @returns {Array} 永続化形式のカテゴリ配列（isMaster除外）
+ */
+export function toPersistCategories(runtimeCategories) {
+  return runtimeCategories.map(({ isMaster, ...cat }) => cat);
+}
+
+/**
+ * ランタイム形式 → 永続化形式: 装備
+ * @param {Array} runtimeEquipments - ランタイム形式の装備配列
+ * @returns {Array} 永続化形式の装備配列（isMaster, type除外）
+ */
+export function toPersistEquipments(runtimeEquipments) {
+  return runtimeEquipments.map(({ isMaster, type, ...eq }) => eq);
+}
+
+/**
+ * ランタイム形式 → 永続化形式: 任務
+ * @param {Array} runtimeMissions - ランタイム形式の任務配列
+ * @returns {Array} 永続化形式の任務配列（isMaster除外）
+ */
+export function toPersistMissions(runtimeMissions) {
+  return runtimeMissions.map(({ isMaster, ...ms }) => ms);
+}

--- a/src/utils/localStorage.js
+++ b/src/utils/localStorage.js
@@ -8,6 +8,7 @@ import { STORAGE_KEYS, SCHEMA_VERSION } from '../types/schema.js';
 import { validateEquipment, validateMission, validateName } from './validation.js';
 import { createStorageHelper } from './storageHelper.js';
 import { logError, logWarning, logInfo } from './logger.js';
+import { toRuntimeCategories, toRuntimeEquipments, toRuntimeMissions, toPersistCategories, toPersistEquipments, toPersistMissions } from './dataConverter.js';
 
 // LocalStorage操作用のヘルパー関数
 const { getItem, setItem, removeItem } = createStorageHelper(localStorage, 'LocalStorage');
@@ -17,11 +18,12 @@ const { getItem, setItem, removeItem } = createStorageHelper(localStorage, 'Loca
  * @param {string} storageKey - StorageKey
  * @param {string} dataKey - データキー名（'equipments'/'missions'）
  * @param {Function} validateFn - バリデーション関数
+ * @param {Function} toRuntimeFn - 永続化形式→ランタイム形式変換関数
  * @param {Function} saveFn - 保存関数
  * @param {string} dataType - データ種別（ログ用）
  * @returns {{data: Array, corruptedItems: Array}} データと破損アイテム情報
  */
-function loadAndValidateUserData(storageKey, dataKey, validateFn, saveFn, dataType) {
+function loadAndValidateUserData(storageKey, dataKey, validateFn, toRuntimeFn, saveFn, dataType) {
   const rawData = getItem(storageKey);
   if (!rawData || !rawData[dataKey]) {
     logInfo(`No user ${dataType} found`, { function: 'loadAndValidateUserData', dataType });
@@ -29,14 +31,13 @@ function loadAndValidateUserData(storageKey, dataKey, validateFn, saveFn, dataTy
   }
 
   // 起動時バリデーション
-  const validItems = [];
+  const validPersistedItems = [];
   const corruptedItems = [];
 
   rawData[dataKey].forEach((item) => {
     const validation = validateFn(item);
     if (validation.valid) {
-      // isMaster: false を付与
-      validItems.push({ ...item, isMaster: false });
+      validPersistedItems.push(item);
     } else {
       logWarning(`Corrupted ${dataType} detected`, {
         function: 'loadAndValidateUserData',
@@ -52,6 +53,9 @@ function loadAndValidateUserData(storageKey, dataKey, validateFn, saveFn, dataTy
       });
     }
   });
+
+  // 永続化形式 → ランタイム形式に変換
+  const validItems = toRuntimeFn(validPersistedItems, false);
 
   // 破損データがあれば正常なデータのみで上書き保存
   if (corruptedItems.length > 0) {
@@ -77,17 +81,17 @@ function loadAndValidateUserData(storageKey, dataKey, validateFn, saveFn, dataTy
  * @throws {Error} 保存に失敗した場合
  */
 export function saveUserCategories(categories) {
-  // isMasterフィールドを除外（仕様: JSONには含まれない）
-  const cleanedCategories = categories.map(({ isMaster, ...cat }) => cat);
+  // ランタイム形式 → 永続化形式に変換
+  const persistedCategories = toPersistCategories(categories);
 
   const data = {
     version: SCHEMA_VERSION,
-    categories: cleanedCategories,
+    categories: persistedCategories,
   };
   setItem(STORAGE_KEYS.USER_CATEGORIES, data);
   logInfo('Saved user categories', {
     function: 'saveUserCategories',
-    count: cleanedCategories.length,
+    count: persistedCategories.length,
   });
 }
 
@@ -103,7 +107,7 @@ export function loadUserCategories() {
   }
 
   // 簡易バリデーション
-  const validItems = [];
+  const validPersistedItems = [];
   const corruptedItems = [];
 
   rawData.categories.forEach((item) => {
@@ -120,10 +124,12 @@ export function loadUserCategories() {
         errors: ['必須フィールドが不足しています'],
       });
     } else {
-      // isMaster: false を付与
-      validItems.push({ ...item, isMaster: false });
+      validPersistedItems.push(item);
     }
   });
+
+  // 永続化形式 → ランタイム形式に変換
+  const validItems = toRuntimeCategories(validPersistedItems, false);
 
   // 破損データがあれば正常なデータのみで上書き保存
   if (corruptedItems.length > 0) {
@@ -147,17 +153,17 @@ export function loadUserCategories() {
  * @throws {Error} 保存に失敗した場合
  */
 export function saveUserEquipments(equipments) {
-  // isMaster, typeフィールドを除外（仕様: JSONには含まれない）
-  const cleanedEquipments = equipments.map(({ isMaster, type, ...eq }) => eq);
+  // ランタイム形式 → 永続化形式に変換
+  const persistedEquipments = toPersistEquipments(equipments);
 
   const data = {
     version: SCHEMA_VERSION,
-    equipments: cleanedEquipments,
+    equipments: persistedEquipments,
   };
   setItem(STORAGE_KEYS.USER_EQUIPMENTS, data);
   logInfo('Saved user equipments', {
     function: 'saveUserEquipments',
-    count: cleanedEquipments.length,
+    count: persistedEquipments.length,
   });
 }
 
@@ -170,6 +176,7 @@ export function loadUserEquipments() {
     STORAGE_KEYS.USER_EQUIPMENTS,
     'equipments',
     validateEquipment,
+    toRuntimeEquipments,
     saveUserEquipments,
     'equipment'
   );
@@ -181,17 +188,17 @@ export function loadUserEquipments() {
  * @throws {Error} 保存に失敗した場合
  */
 export function saveUserMissions(missions) {
-  // isMasterフィールドを除外（仕様: JSONには含まれない）
-  const cleanedMissions = missions.map(({ isMaster, ...ms }) => ms);
+  // ランタイム形式 → 永続化形式に変換
+  const persistedMissions = toPersistMissions(missions);
 
   const data = {
     version: SCHEMA_VERSION,
-    missions: cleanedMissions,
+    missions: persistedMissions,
   };
   setItem(STORAGE_KEYS.USER_MISSIONS, data);
   logInfo('Saved user missions', {
     function: 'saveUserMissions',
-    count: cleanedMissions.length,
+    count: persistedMissions.length,
   });
 }
 
@@ -204,6 +211,7 @@ export function loadUserMissions() {
     STORAGE_KEYS.USER_MISSIONS,
     'missions',
     validateMission,
+    toRuntimeMissions,
     saveUserMissions,
     'mission'
   );


### PR DESCRIPTION
## 概要

Issue #80 の対応として、永続化形式とランタイム形式の変換処理を集約する専用レイヤーを導入しました。

## 変更内容

### 新規作成

* `src/utils/dataConverter.js`
  * 永続化形式 → ランタイム形式変換: `toRuntimeCategories()`, `toRuntimeEquipments()`, `toRuntimeMissions()`
  * ランタイム形式 → 永続化形式変換: `toPersistCategories()`, `toPersistEquipments()`, `toPersistMissions()`
  * カテゴリ代表生成: `generateCategoryRepresentatives()`
  * 装備type付与: `addEquipmentType()`
  * Map生成: `createCategoryMaps()`, `createEquipmentMap()`

### リファクタ

* `src/hooks/useCategories.js`: `toRuntimeCategories()`, `createCategoryMaps()`を使用
* `src/hooks/useEquipments.js`: `toRuntimeEquipments()`, `generateCategoryRepresentatives()`, `addEquipmentType()`, `createEquipmentMap()`を使用
* `src/hooks/useMissions.js`: `toRuntimeMissions()`を使用
* `src/utils/localStorage.js`: `toPersist*()`, `toRuntime*()`を使用して変換処理を集約

### 命名規則の統一

* `allEquipmentsForUI` → `equipmentsForUI`
* `src/App.jsx`での使用箇所も更新

## 効果

* データ変換処理の重複解消（4箇所 → 1箇所）
* 責務の明確化（永続化層、変換層、フック層の分離）
* 保守性とテスタビリティの向上

## 関連Issue

Closes #80

🤖 Generated with [Claude Code](https://claude.com/claude-code)