### PR TITLE
fix: 初回起動時にAboutモーダルが自動表示されるよう修正 (#72)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import { useCategories } from './hooks/useCategories'
 import { useSelectedMissions } from './hooks/useSelectedMissions'
 import { useScrapCalculation } from './hooks/useScrapCalculation'
 import { useMissionFilter } from './hooks/useMissionFilter'
+import { useAboutModal } from './hooks/useAboutModal'
 import { generateCategoryId, generateEquipmentId, generateMissionId } from './utils/idGenerator'
 import { logInfo } from './utils/logger'
 import {
@@ -58,11 +59,11 @@ function App() {
   } = useMissions()
   const { selectedMissionIds, selectedCount, toggleMission, clearSelection } = useSelectedMissions()
   const { scrapList, calculating: _calculating } = useScrapCalculation(selectedMissionIds, missions, equipmentMap, categoryMap)
+  const { isAboutModalOpen, openAboutModal, closeAboutModal } = useAboutModal()
 
   const [errors, setErrors] = useState([])
   const [activeModal, setActiveModal] = useState(null)
   const [confirmDialog, setConfirmDialog] = useState({ isOpen: false, type: null, id: null, message: '' })
-  const [isAboutModalOpen, setIsAboutModalOpen] = useState(false)
 
   // 選択中の任務一覧を取得
   const selectedMissions = useMemo(() =>
@@ -83,9 +84,6 @@ function App() {
   // エラー状態の統合
   const errorMessage = equipmentsCrudError || missionsCrudError
 
-  const handleAboutOpen = () => {
-    setIsAboutModalOpen(true)
-  }
 
   const handleExport = () => {
     // TODO: issue #12で実装予定
@@ -186,7 +184,7 @@ function App() {
   return (
     <div className="min-h-screen bg-slate-100 text-slate-800 font-sans relative">
       <Header
-        onAboutOpen={handleAboutOpen}
+        onAboutOpen={openAboutModal}
         onExport={handleExport}
         onImport={handleImport}
       />
@@ -300,7 +298,7 @@ function App() {
 
       <AboutModal
         isOpen={isAboutModalOpen}
-        onClose={() => setIsAboutModalOpen(false)}
+        onClose={closeAboutModal}
       />
     </div>
   )

--- a/src/hooks/useAboutModal.js
+++ b/src/hooks/useAboutModal.js
@@ -1,0 +1,50 @@
+/**
+ * Aboutモーダルの状態管理フック
+ * 初回起動時の自動表示と表示済みフラグの管理
+ * @module hooks/useAboutModal
+ */
+
+import { useState, useEffect, useCallback } from 'react';
+import { isAboutShown, saveAboutShown } from '../utils/localStorage.js';
+import { logInfo } from '../utils/logger.js';
+
+/**
+ * Aboutモーダルを管理するカスタムフック
+ * @returns {Object} モーダルの開閉状態と操作関数
+ */
+export function useAboutModal() {
+  const [isAboutModalOpen, setIsAboutModalOpen] = useState(false);
+
+  // 初回マウント時に表示済みフラグをチェック
+  useEffect(() => {
+    const shown = isAboutShown();
+    if (!shown) {
+      // 初回起動時は自動表示
+      setIsAboutModalOpen(true);
+      logInfo('About modal auto-opened on first launch', {
+        function: 'useAboutModal',
+      });
+    }
+  }, []);
+
+  // モーダルを開く
+  const openAboutModal = useCallback(() => {
+    setIsAboutModalOpen(true);
+  }, []);
+
+  // モーダルを閉じる
+  const closeAboutModal = useCallback(() => {
+    setIsAboutModalOpen(false);
+    // 閉じた時点で表示済みフラグを保存
+    saveAboutShown();
+    logInfo('About modal closed, saved as shown', {
+      function: 'useAboutModal',
+    });
+  }, []);
+
+  return {
+    isAboutModalOpen,
+    openAboutModal,
+    closeAboutModal,
+  };
+}


### PR DESCRIPTION
## Summary

- useAboutModalカスタムフックを新規作成し、初回起動時のAboutモーダル自動表示機能を実装
- App.jxでuseAboutModalを使用するよう変更

## Changes

### 新規作成
- `src/hooks/useAboutModal.js`: Aboutモーダルの状態管理と初回起動判定ロジック

### 修正
- `src/App.jsx`: useAboutModalフックの使用、handleAboutOpen関数を削除

## Implementation Details

**useAboutModalフック**:
- 初回マウント時に`isAboutShown()`で表示済みフラグをチェック
- 未表示の場合は自動的にモーダルを開く
- モーダルを閉じた時点で`saveAboutShown()`により表示済みフラグを保存

**既存パターンとの一貫性**:
- `useSelectedMissions`, `useMissionFilter`等と同様のフック層での状態管理
- LocalStorageアクセスは既存の`localStorage.js`の関数を使用

## Related Issue

Closes #72

🤖 Generated with [Claude Code](https://claude.com/claude-code)