### PR TITLE
feat: 任務の編集機能を追加 (#73)

### DIFF
--- a/docs/progress_v2.md
+++ b/docs/progress_v2.md
@@ -414,7 +414,32 @@ DailyやWeekly（あるいはMonthly...）を複数回実行することで、�
 
 * **Priority**: P2
 * **実装内容**: 既存任務の編集モーダル、MissionCardに編集ボタン追加
-* **影響範囲**: `src/components/MissionModal.jsx`, `src/components/MissionCard.jsx`, `src/App.jsx`
+* **影響範囲**: `src/components/MissionModal.jsx`, `src/components/MissionCard.jsx`, `src/components/MissionList.jsx`, `src/App.jsx`
+* **ステータス**: 完了 (2025-12-05)
+
+**実装詳細**:
+
+1. **MissionModalの編集モード対応**:
+   - `editingMission`プロップを追加（編集対象の任務、追加時はnull）
+   - 編集時は既存の任務データを初期値として設定
+   - 保存時に`id`と`order`を保持（編集時は既存値、追加時は新規生成）
+   - ボタンテキストを「追加」「更新」に切り替え
+
+2. **MissionCardの編集ボタン追加**:
+   - ユーザー定義任務に編集ボタンを追加（Edit2アイコン）
+   - 編集ボタンと削除ボタンを横並びで配置
+   - 編集ボタンクリック時に`onEdit(mission)`を呼び出し
+
+3. **App.jxの編集ロジック実装**:
+   - `updateUserMission`を`useMissions`フックから取得
+   - `editingMission`ステートを追加（編集中の任務を管理）
+   - `handleEditMission`: 編集対象の任務を設定してモーダルを開く
+   - `handleSaveMission`: 追加・編集を統合処理（`data.id`の有無で判定）
+   - モーダルを閉じる際に`editingMission`をリセット
+   - `MissionList`に`onEdit`プロップを渡す
+
+4. **MissionListのプロップス追加**:
+   - `onEdit`プロップを追加し、`MissionCard`に渡す
 
 #### #12: インポート/エクスポート処理
 
@@ -503,7 +528,8 @@ DailyやWeekly（あるいはMonthly...）を複数回実行することで、�
   - Issue #76: ベース任務と補助任務の分離 - 完了
 * ⏳ **Phase 4**: バグ修正・小規模改善 - 一部完了
   - Issue #72: 完了
-  - その他（#73, #12, #43, #11, #10, #9, #78, #100）: 未着手
+  - Issue #73: 完了
+  - その他（#12, #43, #11, #10, #9, #78, #100）: 未着手
 
 ### 次のステップ
 
@@ -511,7 +537,7 @@ Phase 3 が完了したため、v2.0.0 のコア機能が完成した。次は P
 
 **推奨実装順序**:
 
-1. **Issue #73**: 任務編集機能（P2）- 基本機能の拡充
+1. ~~**Issue #73**: 任務編集機能（P2）- 基本機能の拡充~~ ✅ 完了
 2. **Issue #12**: インポート/エクスポート（P2）- データ管理機能の強化
 3. **Issue #100**: データ初期化機能（P2）- データ管理機能の強化
 4. **Issue #9**: プライベートモード検出（P2）- エラー処理の強化

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -58,6 +58,7 @@ function App() {
     crudError: missionsCrudError,
     corruptedItems: corruptedMissions,
     addUserMission,
+    updateUserMission,
     deleteUserMission,
     getNextOrder: getNextMissionOrder
   } = useMissions()
@@ -92,6 +93,7 @@ function App() {
 
   const [errors, setErrors] = useState([])
   const [activeModal, setActiveModal] = useState(null)
+  const [editingMission, setEditingMission] = useState(null) // 編集中の任務
   const [confirmDialog, setConfirmDialog] = useState({ isOpen: false, type: null, id: null, message: '' })
 
   // フィルタリング
@@ -174,6 +176,27 @@ function App() {
     }
     addUserMission(newMission)
     setActiveModal(null)
+  }
+
+  const handleEditMission = (mission) => {
+    setEditingMission(mission)
+    setActiveModal('mission')
+  }
+
+  const handleSaveMission = (data) => {
+    if (data.id) {
+      // 編集モード: 既存の任務を更新
+      updateUserMission(data.id, data)
+    } else {
+      // 追加モード: 新規任務を追加
+      const newMission = {
+        ...data,
+        id: generateMissionId() // dataを先に展開してからidで上書き
+      }
+      addUserMission(newMission)
+    }
+    setActiveModal(null)
+    setEditingMission(null)
   }
 
   const handleDeleteMission = (id) => {
@@ -282,6 +305,7 @@ function App() {
             isBaseMission={isBaseMission}
             onToggle={toggleMission}
             onDelete={handleDeleteMission}
+            onEdit={handleEditMission}
           />
         )}
       </div>
@@ -310,17 +334,24 @@ function App() {
 
       <Modal
         isOpen={activeModal === 'mission'}
-        title="任務を追加"
-        onClose={() => setActiveModal(null)}
+        title={editingMission ? '任務を編集' : '任務を追加'}
+        onClose={() => {
+          setActiveModal(null)
+          setEditingMission(null)
+        }}
       >
         <MissionModal
+          editingMission={editingMission}
           equipments={equipments}
           categories={categories}
           missions={missions}
           getCategoryName={getCategoryName}
           getNextOrder={getNextMissionOrder}
-          onSave={handleAddMission}
-          onCancel={() => setActiveModal(null)}
+          onSave={handleSaveMission}
+          onCancel={() => {
+            setActiveModal(null)
+            setEditingMission(null)
+          }}
         />
       </Modal>
 

--- a/src/components/MissionCard.jsx
+++ b/src/components/MissionCard.jsx
@@ -1,4 +1,4 @@
-import { Trash2, Target } from 'lucide-react'
+import { Trash2, Target, Edit2 } from 'lucide-react'
 import { TARGET_TYPE } from '../types/schema'
 
 const MissionCard = ({
@@ -9,7 +9,8 @@ const MissionCard = ({
   isBaseMission = false,
   isDisabled = false,
   onToggle,
-  onDelete
+  onDelete,
+  onEdit
 }) => {
   const isUserDefined = mission.id.startsWith('u_')
 
@@ -64,17 +65,30 @@ const MissionCard = ({
           </div>
         </div>
 
-        {/* ユーザー定義削除ボタン */}
+        {/* ユーザー定義の編集・削除ボタン */}
         {isUserDefined && (
-          <button
-            onClick={(e) => {
-              e.preventDefault()
-              onDelete(mission.id)
-            }}
-            className="text-slate-300 hover:text-red-500 p-1"
-          >
-            <Trash2 className="w-4 h-4" />
-          </button>
+          <div className="flex gap-1">
+            <button
+              onClick={(e) => {
+                e.preventDefault()
+                onEdit(mission)
+              }}
+              className="text-slate-300 hover:text-blue-500 p-1"
+              title="編集"
+            >
+              <Edit2 className="w-4 h-4" />
+            </button>
+            <button
+              onClick={(e) => {
+                e.preventDefault()
+                onDelete(mission.id)
+              }}
+              className="text-slate-300 hover:text-red-500 p-1"
+              title="削除"
+            >
+              <Trash2 className="w-4 h-4" />
+            </button>
+          </div>
         )}
       </div>
     </label>

--- a/src/components/MissionList.jsx
+++ b/src/components/MissionList.jsx
@@ -9,7 +9,8 @@ const MissionList = ({
   selectedCount,
   isBaseMission,
   onToggle,
-  onDelete
+  onDelete,
+  onEdit
 }) => {
   const isMaxSelected = selectedCount >= LIMITS.SELECTED_MISSIONS_MAX
   if (missions.length === 0) {
@@ -37,6 +38,7 @@ const MissionList = ({
             isDisabled={isDisabled}
             onToggle={onToggle}
             onDelete={onDelete}
+            onEdit={onEdit}
           />
         )
       })}

--- a/src/components/MissionModal.jsx
+++ b/src/components/MissionModal.jsx
@@ -4,13 +4,26 @@ import { PERIOD, LIMITS, TARGET_TYPE } from '../types/schema'
 import { validateName } from '../utils/validation'
 import ValidationErrorDisplay from './ValidationErrorDisplay'
 
-const MissionModal = ({ equipments, categories, missions, getCategoryName, getNextOrder, onSave, onCancel }) => {
-  const [name, setName] = useState('')
-  const [period, setPeriod] = useState('Weekly')
+const MissionModal = ({
+  editingMission = null, // 編集対象の任務（追加時はnull）
+  equipments,
+  categories,
+  missions,
+  getCategoryName,
+  getNextOrder,
+  onSave,
+  onCancel
+}) => {
+  const isEditMode = editingMission !== null
+
+  const [name, setName] = useState(editingMission?.name || '')
+  const [period, setPeriod] = useState(editingMission?.period || 'Weekly')
   // 複数の要求装備を管理（最初の1枠は必須）
-  const [reqs, setReqs] = useState([
-    { id: crypto.randomUUID(), targetId: equipments[0]?.id || '', count: 1 }
-  ])
+  const [reqs, setReqs] = useState(
+    editingMission?.reqs?.length > 0
+      ? editingMission.reqs.map(req => ({ ...req, id: crypto.randomUUID() }))
+      : [{ id: crypto.randomUUID(), targetId: equipments[0]?.id || '', count: 1 }]
+  )
 
   // 装備追加
   const addReq = () => {
@@ -99,6 +112,7 @@ const MissionModal = ({ equipments, categories, missions, getCategoryName, getNe
     if (!isFormValid) return
     // 複数の装備要求に対応（targetTypeを自動判定）
     onSave({
+      id: isEditMode ? editingMission.id : undefined, // 編集時は既存ID、追加時は未定義
       name,
       period,
       reqs: reqs.map(req => {
@@ -111,7 +125,7 @@ const MissionModal = ({ equipments, categories, missions, getCategoryName, getNe
           count: parseInt(req.count)
         }
       }),
-      order: getNextOrder()
+      order: isEditMode ? editingMission.order : getNextOrder() // 編集時は既存order、追加時は新規order
     })
   }
 
@@ -228,7 +242,7 @@ const MissionModal = ({ equipments, categories, missions, getCategoryName, getNe
               : 'bg-slate-200 text-slate-400 cursor-not-allowed'
           }`}
         >
-          追加
+          {isEditMode ? '更新' : '追加'}
         </button>
       </div>
     </form>


### PR DESCRIPTION
## Summary

ユーザー定義任務の編集機能を実装.

## 主な変更

* **MissionModal**: 編集モード対応（editingMissionプロップ追加）
* **MissionCard**: 編集ボタン追加（Edit2アイコン）
* **MissionList**: onEditプロップの追加とMissionCardへの受け渡し
* **App.jx**: 編集ロジック実装（handleEditMission, handleSaveMission）
* **progress_v2.md**: Issue #73の完了記録

## 実装詳細

1. **MissionModalの編集モード対応**:
   - `editingMission`プロップを追加（編集対象の任務、追加時はnull）
   - 編集時は既存の任務データを初期値として設定
   - 保存時にidとorderを保持（編集時は既存値、追加時は新規生成）
   - モーダルタイトルとボタンテキストを編集モードに応じて切り替え

2. **MissionCardの編集ボタン追加**:
   - ユーザー定義任務に編集ボタンを追加（Edit2アイコン）
   - 編集ボタンと削除ボタンを横並びで配置
   - 編集ボタンクリック時に`onEdit(mission)`を呼び出し

3. **App.jxの編集ロジック実装**:
   - `updateUserMission`を`useMissions`フックから取得
   - `editingMission`ステートを追加（編集中の任務を管理）
   - `handleEditMission`: 編集対象の任務を設定してモーダルを開く
   - `handleSaveMission`: 追加・編集を統合処理（data.idの有無で判定）
   - モーダルを閉じる際にeditingMissionをリセット

4. **バグ修正**:
   - スプレッド演算子の順序を修正し、新規任務のID生成が正しく行われるように修正
   - `updateUserMission`の呼び出しを正しいシグネチャ（id, data）に修正

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>