### PR TITLE
fix: 任務追加モーダルでカテゴリ代表装備の「（種別不問）」重複表示を修正

### DIFF
--- a/src/components/MissionModal.jsx
+++ b/src/components/MissionModal.jsx
@@ -188,7 +188,7 @@ const MissionModal = ({
                   <optgroup key={categoryId} label={getCategoryName(categoryId)}>
                     {categoryEquipments.map(e => (
                       <option key={e.id} value={e.id}>
-                        {e.name} ({e.type === 'category' ? '種別不問' : '個別装備'})
+                        {e.name}
                       </option>
                     ))}
                   </optgroup>


### PR DESCRIPTION
## Summary

MissionModalのselect要素で, カテゴリ代表装備のnameに既に含まれている「（種別不問）」を再度追加していた問題を修正.

## Changes

- MissionModal.jsx: option要素の表示を `{e.name}` のみに変更（`({e.type === 'category' ? '種別不問' : '個別装備'})` を削除）- カテゴリ代表装備は `dataConverter.js` で生成時に既に「（種別不問）」が name に含まれているため, 重複表示を回避

## Verification

- npm run build

## Related

- Fixes #133

🤖 Generated with [Claude Code](https://claude.com/claude-code)