### PR TITLE
chore: デプロイ時にリモートの旧アセットを自動削除する

### DIFF
--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -21,7 +21,7 @@ dotenv.config({ path: join(__dirname, '..', '.env') })
  */
 const FTP_CONFIG = {
   port: 21,
-  deleteRemote: false, // trueにするとサーバー上の不要ファイルを削除
+  deleteRemote: true, // サーバー上の不要ファイル（旧ハッシュのアセット等）を削除
   forcePasv: true,
   secure: false, // 通常のFTP接続
 }


### PR DESCRIPTION
## Summary

- `deleteRemote` を `true` に変更し、ビルドごとにハッシュが変わる旧アセット（`index-xxxx.css` / `index-xxxx.js`）がサーバーに残留する問題を解消
- 削除範囲は `remoteRoot`（`app/kancolle-scrap-manager/`）配下のみ。親ディレクトリの `.htaccess` 等には影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)