### PR TITLE
feat: シークレットモード時のデータ消失に関する注意書きを追加

### DIFF
--- a/src/components/AboutModal.tsx
+++ b/src/components/AboutModal.tsx
@@ -55,6 +55,9 @@ export default function AboutModal({ isOpen, onClose }: Props) {
                         <p>
                             入力されたデータが外部サーバーへ送信されることはありません。
                         </p>
+                        <p className="text-amber-700 font-medium">
+                            シークレットモード（プライベートブラウジング）ではブラウザを閉じるとデータが消失します。通常モードでのご利用を推奨します。
+                        </p>
                     </div>
                 </div>
 


### PR DESCRIPTION
## Summary

- Aboutモーダルの「データの取り扱い」セクションに、シークレットモード（プライベートブラウジング）でのデータ消失に関する警告文を追加
- 現代のブラウザではシークレットモードでもLocalStorageへの書き込みが可能なため、技術的な検出ではなく注意喚起による対応とした

## 方針変更の背景

Issue #9 では当初LocalStorageの書き込みテストによるプライベートモード検出を想定していたが、現在の主要ブラウザ（Chrome, Firefox, Safari, Edge）ではシークレットモードでもLocalStorageが正常に動作する。実際の問題は「書き込みができない」ではなく「ウィンドウを閉じるとデータが消失する」ことであり、確実な技術的検出手段がないため注意喚起のみとした。

## ドキュメント更新

AboutModal内の注意書きで対応しており、外部ドキュメントの更新は不要。

Closes #9

🤖 Generated with [Claude Code](https://claude.com/claude-code)